### PR TITLE
Fix "Recipes" typo

### DIFF
--- a/src/AnglerAtlas/UI/Recipes.lua
+++ b/src/AnglerAtlas/UI/Recipes.lua
@@ -1,4 +1,4 @@
-local Resipes = {}
+local Recipes = {}
 
 local UI = AnglerAtlas.MM:GetModule("UI")
 local STATE = AnglerAtlas.MM:GetModule("STATE")
@@ -8,7 +8,7 @@ local GoldDisplay = AnglerAtlas.MM:GetModule("GoldDisplay")
 
 local recipes = nil
 
-function Resipes:Create(uiParent, anchor)
+function Recipes:Create(uiParent, anchor)
     recipes = CreateFrame("FRAME", "angler-recipes-info", uiParent, "BackdropTemplate")
     recipes:Raise()
     recipes:SetBackdrop(UI.ANGLER_BACKDROP)
@@ -190,7 +190,7 @@ function Resipes:Create(uiParent, anchor)
 end
 
 
-function Resipes:Update()
+function Recipes:Update()
     if recipes == nil then
         error("Recipes frame not created")
         return
@@ -222,4 +222,4 @@ function Resipes:Update()
     end
 end
 
-AnglerAtlas.MM:RegisterModule("Resipes", Resipes)
+AnglerAtlas.MM:RegisterModule("Recipes", Recipes)

--- a/src/AnglerAtlas/UI/RightSideInformationPanel.lua
+++ b/src/AnglerAtlas/UI/RightSideInformationPanel.lua
@@ -4,7 +4,7 @@ local UI = AnglerAtlas.MM:GetModule("UI")
 
 local TabManager = AnglerAtlas.MM:GetModule("TabManager")
 local ZoneInfo = AnglerAtlas.MM:GetModule("ZoneInfo")
-local Resipes = AnglerAtlas.MM:GetModule("Resipes")
+local Recipes = AnglerAtlas.MM:GetModule("Recipes")
 local Equipment = AnglerAtlas.MM:GetModule("Equipment")
 
 function RightSideInformationPanel:Create(uiParent)
@@ -20,7 +20,7 @@ function RightSideInformationPanel:Create(uiParent)
     local zoneInfo = ZoneInfo:Create(container)
 
     -- Make the recipes panel
-    local resipesUI = Resipes:Create(container, zoneInfo)
+    local RecipesUI = Recipes:Create(container, zoneInfo)
 
     -- Make the equipment panel
     local equipmentUI = Equipment:Create(container, zoneInfo)
@@ -37,7 +37,7 @@ function RightSideInformationPanel:Create(uiParent)
 
     -- Register the tabs
     tabManager:Register('default', defaultToggleButton, zoneInfo)
-    tabManager:Register('recipes', recipesToggleButton, resipesUI)
+    tabManager:Register('recipes', recipesToggleButton, RecipesUI)
     tabManager:Register('equipment', equipmentToggleButton, equipmentUI)
 
     tabManager:Select('default')

--- a/src/AnglerAtlas/UI/UI.lua
+++ b/src/AnglerAtlas/UI/UI.lua
@@ -16,7 +16,7 @@ local ZonesList = AnglerAtlas.MM:GetModule("ZonesList")
 
 local ZoneInfo = AnglerAtlas.MM:GetModule("ZoneInfo")
 
-local Resipes = AnglerAtlas.MM:GetModule("Resipes")
+local Recipes = AnglerAtlas.MM:GetModule("Recipes")
 
 local RightSideInformationPanel = AnglerAtlas.MM:GetModule("RightSideInformationPanel")
 
@@ -187,7 +187,7 @@ function UI:SelectFish(fishId, skipZoneSelect)
 
     FishGrid:Update()
     FishInfo:Update()
-    Resipes:Update()
+    Recipes:Update()
     MapFishRates:Update()
     if not skipZoneSelect then
         UI:SelectZone(tostring(zones[1].id), true)
@@ -242,7 +242,7 @@ function UI:ReloadAll()
         return
     end
     UI:Reload()
-    Resipes:Update()
+    Recipes:Update()
     SetPortraitTexture(UI.fd.characterPortrait.texture, "player");
     UI.playerName:SetText(DATA.playerInfo.name)
 end


### PR DESCRIPTION
`Resipes` -> `Recipes`

Noticed it when the module was loading and it wrote "Resipes" in chat.

It appears to work when I tested these changes, but it's my first time contributing, so I'd appreciate if someone else gave it these changes a test as well.